### PR TITLE
Fix wrong NPM package name used in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A quick, easy and light-weight way to add chain / network icons to your react ap
 ## Installation
 
 ```sh
-yarn add @thirdweb/chain-icons
+yarn add @thirdweb-dev/chain-icons
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ _Example of using the Polygon Icon_
 
 ```jsx
 import React from "react";
-import { Polygon } from "@thirdweb/chain-icons";
+import { Polygon } from "@thirdweb-dev/chain-icons";
 
 const App = () => {
   return (


### PR DESCRIPTION
Change `@thirdweb/chain-icons` to `@thirdweb-dev/chain-icons`